### PR TITLE
Fixed the name of the font to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,27 +3,26 @@
 This project started as a small request and template sharing thread over gbatemp, it eventually grow into a big project which goal is set a standart for Wii U injection, now it adds practically all injectable console templates.   
 
 ## Banner/icon creation guidelines:
-* The template is pretty self-explanatory, you will need SCE-PS3 Rodin Latin Bold font, for japanese titles use Kozuka Gothic Pr6N font.
+* The template is pretty self-explanatory, you will need Rodin NTLG Pro bold and regular fonts.
 * Title screens resizing should use bicubic interpolation.
 
-## This repo includes: 
+## This repo includes:
 * A collection of Wii banners (.bnr)
 * A collection of WiiWare banners (.bnr)
-* A collection of injected VC banners (GCN, NDS, N64, etc.) 
+* A collection of injected VC banners (GCN, NDS, N64, etc.)
 
 ## Credits:
-* Improved GCN template (by cucholix) 
+* Improved GCN template (by cucholix)
 * MSX template (by cucholix)
-* N64 template (by Crazystato) 
-* Improved SNES template (by dj_skual) 
+* N64 template (by Crazystato)
+* Improved SNES template (by dj_skual)
 * Improved NES template (by cucholix)
-* NDS template (by Crazystato) 
-* GBC template (Atomic Purple) (by cucholix) 
-* GBA template (by Crazystato) 
+* NDS template (by Crazystato)
+* GBC template (Atomic Purple) (by cucholix)
+* GBA template (by Crazystato)
 * TG16 template (by markehmus)
-* Improved TG16 template (by dj_skual) 
+* Improved TG16 template (by dj_skual)
 * TG16 CD template (by markehmus)
-* PCE/CD (by cucholix) 
+* PCE/CD (by cucholix)
 * Famicom and Super Famicom (by dj_skual)
 * PAL NES and SNES (by dj_skual)
-


### PR DESCRIPTION
The actual name of the font is "FOT-Rodin NTLG Pro", made by a company called Fontworks. It has the Japanese and English characters in one font, and I updated the template and README to reflect on the change.